### PR TITLE
bump jast-jwt to latest 4.0.1

### DIFF
--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -79,7 +79,7 @@
     "dotenv": "^16.0.3",
     "esbuild": "0.18.13",
     "express": "^4.18.2",
-    "fast-jwt": "^3.1.1",
+    "fast-jwt": "^4.0.1",
     "get-port": "^6.1.2",
     "glob": "^10.0.0",
     "graphql": "*",


### PR DESCRIPTION
As of May 15, Node version 22 is now the current version. SST is incompatible with version 22 because fast-jwt version 3 caps the node version under version 22. 

If sst upgrades fast-jwt to at least version 4.0.1 (https://github.com/nearform/fast-jwt/commit/bad137f7b5df562a64ed99142865623bea7e484b) then I think sst would become compatible with the latest version of node.

Thread posted in discord about this: https://discord.com/channels/983865673656705025/1243349186649526293/1243349186649526293